### PR TITLE
[DP-26] enable pgcrypto module to support DSpace 6, add ImageMagick role

### DIFF
--- a/uclalib_dspace.yml
+++ b/uclalib_dspace.yml
@@ -55,6 +55,7 @@
   roles:
     - { role: uclalib_role_java }
     - { role: uclalib_role_vim }
+    - { role: uclalib_role_imagemagick }
     - { role: uclalib_role_clamav }
     - { role: uclalib_role_java_maven }
     - { role: uclalib_role_java_ant }

--- a/uclalib_dspace.yml
+++ b/uclalib_dspace.yml
@@ -12,8 +12,11 @@
   # ANXS/PostgreSQL role (https://github.com/ANXS/postgresql)
 
   vars:
-    java_package: java-1.7.0-openjdk-devel.x86_64
+    java_package: java-1.8.0-openjdk-devel.x86_64
 
+    handle_version: 8.1.1
+    tomcat_major_version: 7
+    tomcat_version: 7.0.73
     postgresql_version: 9.5
     postgresql_encoding: 'UTF-8'
     postgresql_locale: 'en_US.UTF-8'
@@ -64,5 +67,6 @@
     - { role: uclalib_role_apache }
     - { role: uclalib_role_tomcat }
     - { role: uclalib_role_dspace }
+    - { role: uclalib_role_handle }
 
 

--- a/uclalib_dspace.yml
+++ b/uclalib_dspace.yml
@@ -37,10 +37,10 @@
         lc_ctype: 'en_US.UTF-8'
 
     # OPTIONAL: you can specify database extensions here (like pgcrypto, which is required for DSapce 6)
-    # postgresql_database_extensions:
-    #    - db: "{{ dspace_db_name }}"
-    #      extensions:
-    #          - pgcrypto
+    postgresql_database_extensions:
+      - db: "{{ dspace_db_name }}"
+        extensions:
+          - pgcrypto
 
     # database privileges for the dspace user
     postgresql_user_privileges:

--- a/vars/dspace_vars_open.yml
+++ b/vars/dspace_vars_open.yml
@@ -3,6 +3,7 @@
 # Public vars for the DSpace playbook go here
 
 dspace_git_repo: http://github.com/UCLALibrary/DSpace.git
+rhr_git_repo: http://github.com/UCLALibrary/Remote-Handle-Resolver.git
 dspace_env_build_name: uclalib_dspilot
 
 dspace_name: UCLA Library DSpace Pilot

--- a/vars/dspace_vars_open.yml
+++ b/vars/dspace_vars_open.yml
@@ -12,11 +12,11 @@ dspace_ui: jspui
 dspace_solr_server: http://localhost:8081/solr
 dspace_default_language: en_US
 
-dspace_mail_from_address: hpottinger@library.ucla.edu
-dspace_mail_feedback_recipient: hpottinger@library.ucla.edu
-dspace_mail_admin: hpottinger@library.ucla.edu
-dspace_mail_alert_recipient: hpottinger@library.ucla.edu
-dspace_mail_registration_notify: hpottinger@library.ucla.edu
+dspace_mail_from_address: dataden@library.ucla.edu
+dspace_mail_feedback_recipient: dataden@library.ucla.edu
+dspace_mail_admin: dataden@library.ucla.edu
+dspace_mail_alert_recipient: dataden@library.ucla.edu
+dspace_mail_registration_notify: dataden@library.ucla.edu
 
 dspace_loglevel_other: INFO
 dspace_loglevel_dspace: INFO


### PR DESCRIPTION
enables the the pgcrypto module, which is required for DSpace 6, and adds the ImageMagick role to install ImageMagick in support of PDF thumbnails