### PR TITLE
LX-495: Add drush role to sandbox build for www.library.ucla.edu

### DIFF
--- a/sandbox/www.library.ucla.edu/localdev-build.yml
+++ b/sandbox/www.library.ucla.edu/localdev-build.yml
@@ -52,3 +52,4 @@
     - { role: uclalib_role_apache }
     - { role: uclalib_role_php }
     - { role: uclalib_role_mysql, tags: ['client', 'server'], mysql_install_version: '5.6' }
+    - { role: uclalib_role_drush }

--- a/sandbox/www.library.ucla.edu/requirements.yml
+++ b/sandbox/www.library.ucla.edu/requirements.yml
@@ -5,3 +5,5 @@
 - src: https://github.com/UCLALibrary/uclalib_role_rhel7repos.git
 
 - src: https://github.com/UCLALibrary/uclalib_role_php.git
+
+- src: https://github.com/UCLALibrary/uclalib_role_drush.git


### PR DESCRIPTION
@cachemeoutside This adds composer/drush to the build, via the `uclalib_role_drush` role.