### PR TITLE
Fix drush post-deploy commands

### DIFF
--- a/www_library/drupal_deploy_post.yml
+++ b/www_library/drupal_deploy_post.yml
@@ -15,7 +15,7 @@
   tasks:
     - name: "Drush trigger updatedb on {{ APP_ENV }}"
       shell: |
-        "{{ drush_path }}" @"{{ drush_configs[APP_ENV]['drush_alias'] }}" updatedb
+        "{{ drush_path }}" @"{{ drush_configs[APP_ENV]['drush_alias'] }}" updatedb -y
       become: yes
       become_user: "{{ drush_user }}"
     - name: "Drush trigger cache clear on {{ APP_ENV }}"
@@ -25,7 +25,7 @@
       become_user: "{{ drush_user }}"
     - name: "Drush trigger features revert on {{ APP_ENV }}"
       shell: |
-        "{{ drush_path }}" @"{{ drush_configs[APP_ENV]['drush_alias'] }}" features revert
+        "{{ drush_path }}" @"{{ drush_configs[APP_ENV]['drush_alias'] }}" features-revert-all -y
       become: yes
       become_user: "{{ drush_user }}"
     - name: "Drush trigger cache clear on {{ APP_ENV }}"


### PR DESCRIPTION
@cachemeoutside The post-deploy drush commands need two fixes, in this PR:
* `updatedb` runs OK when there are no database updates, but needs a `-y` flag when there are updates.  This is safe when there are no updates as well.
* `features revert` should actually be `features-revert-all`, and the `-y` flag is required.  The current command is being interpreted as just `features`, which just lists the features in the output.

Thanks --Andy