### PR TITLE
Fix test for reboot flags

### DIFF
--- a/uclalib_rhelreboot.yml
+++ b/uclalib_rhelreboot.yml
@@ -52,7 +52,7 @@
     - name: Reboot if required
       reboot:
       when: >
-        needs_restarting.failed
+        needs_restarting.rc == 1
         and (needs_restarting.stdout | default("")) is search ("Reboot is required")
         and (skip.content is not defined)
         or ( force_reboot | default (False) )


### PR DESCRIPTION
failed_when: false sets .failed to false, but leaves the rc alone.
Testing on rc==1 let's us still see if a reboot is required.

I didn't catch this before the previous PR.