### PR TITLE
Manage RHEL update snapshots

### DIFF
--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -96,18 +96,25 @@
               }}
           loop: "{{ snapshots.guest_snapshots.snapshots }}"
 
-
-        - name: List the snapshot names
-          debug:
-            msg: >
-              Snapshot: {{ item.name }} ->
-              {{ item.creation_time | to_datetime(date_format_snapshot) }}
+        - name: Remove outdated snapshots
+          vmware_guest_snapshot:
+            datacenter: "{{ vsphere_datacenter }}"
+            state: absent
+            folder: "{{ vsphere_folder }}"
+            hostname: "{{ vcenter_hostname }}"
+            password: "{{ vsphere_password }}"
+            name: "{{ ansible_hostname }}"
+            snapshot_name: "{{ item.name }}"
+            username: "{{ vsphere_username }}"
+          connection: local
+          when:
+            - ( (ansible_date_time.iso8601 | to_datetime(date_format_ansible ))
+              - (item.creation_time        | to_datetime(date_format_snapshot))
+              ).total_seconds()
+              > days_to_keep_snapshots|int * 86400
+            - item.name | regex_search( "^" + snapshot_prefix )
+            - remove_snapshot | bool
           loop: "{{ snapshots.guest_snapshots.snapshots }}"
-          when: >
-            ( (ansible_date_time.iso8601 | to_datetime(date_format_ansible ))
-            - (item.creation_time        | to_datetime(date_format_snapshot))
-            ).total_seconds()
-            > days_to_keep_snapshots|int * 86400
 
       # end block
       when:

--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -9,7 +9,14 @@
     vsphere_datacenter: "Library Information Technology"
     vsphere_domain: "ad.library.ucla.edu"
     vsphere_folder: "/"
-    snapshot_name: "rhel-update"
+    snapshot_prefix: "rhel-update"
+    remove_snapshot: false
+    #date_format: "%Y-%m-%dT%H:%M:%S.%f%z" # for python3
+    date_format_snapshot: "%Y-%m-%dT%H:%M:%S.%f+00:00" # for python2, assuming UTC
+    date_format_ansible: "%Y-%m-%dT%H:%M:%SZ"
+    days_to_keep_snapshots: 7
+    # ansible_date_time.epoch
+
 
   vars_prompt:
   - name: vsphere_user
@@ -22,15 +29,81 @@
 
   tasks:
 
-  - name: Manage Snapshot
-    vmware_guest_snapshot:
-      datacenter: "{{ vsphere_datacenter }}"
-      state: "{{ (remove_snapshot | default(false)) | ternary('absent','present') }}"
-      folder: "{{ vsphere_folder }}"
-      hostname: "{{ vcenter_hostname }}"
-      password: "{{ vsphere_password }}"
-      name: "{{ inventory_hostname | regex_replace ('\\..*') }}"
-      quiesce: true
-      snapshot_name: "{{ snapshot_name }}"
-      username: "{{ vsphere_user }}@{{ vsphere_domain }}"
-    connection: local
+  - name: Gathering Facts
+    setup:
+      fact_path: omit
+      gather_subset: "!all,virtual"
+
+  - name: Set vSphere username (implicit domain)
+    set_fact:
+      vsphere_username: "{{ vsphere_user }}{{ '@' + vsphere_domain }}"
+    when: vsphere_user is not search("@")
+
+  - name: Set vSphere username (explicit domain)
+    set_fact:
+      vsphere_username: "{{ vsphere_user }}"
+    when: vsphere_user is search("@")
+
+  - debug: var=ansible_virtualization_type
+  - debug: var=ansible_hostname
+  - debug: var=vsphere_username
+  - debug: msg={{ snapshot_prefix }}-{{ ansible_date_time.date }}
+
+  - block:
+      - name: Get Snapshots
+        vmware_guest_snapshot_info:
+          datacenter: "{{ vsphere_datacenter }}"
+          folder: "{{ vsphere_folder }}"
+          hostname: "{{ vcenter_hostname }}"
+          password: "{{ vsphere_password }}"
+          name: "{{ ansible_hostname }}"
+          username: "{{ vsphere_username }}"
+        connection: local
+        register: snapshots
+
+      - debug: var=snapshots
+
+      - name: Create Snapshots
+        vmware_guest_snapshot:
+          datacenter: "{{ vsphere_datacenter }}"
+          state: present
+          folder: "{{ vsphere_folder }}"
+          hostname: "{{ vcenter_hostname }}"
+          password: "{{ vsphere_password }}"
+          name: "{{ ansible_hostname }}"
+          quiesce: true
+          snapshot_name: "{{ snapshot_prefix }}-{{ ansible_date_time.date }}"
+          username: "{{ vsphere_username }}"
+        connection: local
+        register: out
+        when:
+          - not remove_snapshot
+
+      - debug: var=out
+
+      - debug: var=snapshots.guest_snapshots
+
+      - name: List days of the snapshots
+        debug:
+          msg: >
+            {{
+            (
+              (ansible_date_time.iso8601 | to_datetime(date_format_ansible))
+            - (item.creation_time     | to_datetime(date_format_snapshot))
+               ).total_seconds()
+            }}
+        loop: "{{ snapshots.guest_snapshots.snapshots }}"
+
+
+      - name: List the snapshot names
+        debug:
+          msg: "Snapshot: {{ item.name }} -> {{ item.creation_time | to_datetime(date_format_snapshot) }}"
+        loop: "{{ snapshots.guest_snapshots.snapshots }}"
+        when: >
+          ( (ansible_date_time.iso8601 | to_datetime(date_format_ansible))
+          - (item.creation_time     | to_datetime(date_format_snapshot)) ).total_seconds()
+          > days_to_keep_snapshots|int * 86400
+
+    when:
+      - ansible_virtualization_type == "VMware"
+    # end block

--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -36,7 +36,7 @@
 
     - name: Set vSphere username (implicit domain)
       set_fact:
-        vsphere_username: "{{ vsphere_user }}{{ '@' + vsphere_domain }}"
+        vsphere_username: "{{ vsphere_user + '@' + vsphere_domain }}"
       when: vsphere_user is not search("@")
 
     - name: Set vSphere username (explicit domain)

--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -17,7 +17,6 @@
     date_format_snapshot: "%Y-%m-%dT%H:%M:%S.%f+00:00"
     date_format_ansible: "%Y-%m-%dT%H:%M:%SZ"
     days_to_keep_snapshots: 7
-    # ansible_date_time.epoch
 
   vars_prompt:
     - name: vsphere_user
@@ -44,18 +43,8 @@
         vsphere_username: "{{ vsphere_user }}"
       when: vsphere_user is search("@")
 
+    # snapshot creation/deletion block
     - block:
-        - name: Get Snapshots
-          vmware_guest_snapshot_info:
-            datacenter: "{{ vsphere_datacenter }}"
-            folder: "{{ vsphere_folder }}"
-            hostname: "{{ vcenter_hostname }}"
-            password: "{{ vsphere_password }}"
-            name: "{{ ansible_hostname }}"
-            username: "{{ vsphere_username }}"
-          connection: local
-          register: snapshots
-
         - name: Create Snapshots
           vmware_guest_snapshot:
             datacenter: "{{ vsphere_datacenter }}"
@@ -69,28 +58,49 @@
             username: "{{ vsphere_username }}"
           connection: local
           when:
-            - not remove_snapshot
+            - not remove_snapshot|bool
 
-        - name: Remove outdated snapshots
-          vmware_guest_snapshot:
-            datacenter: "{{ vsphere_datacenter }}"
-            state: absent
-            folder: "{{ vsphere_folder }}"
-            hostname: "{{ vcenter_hostname }}"
-            password: "{{ vsphere_password }}"
-            name: "{{ ansible_hostname }}"
-            snapshot_name: "{{ item.name }}"
-            username: "{{ vsphere_username }}"
-          connection: local
+        # remove snapshot block
+        - block:
+            - name: Get Snapshots
+              vmware_guest_snapshot_info:
+                datacenter: "{{ vsphere_datacenter }}"
+                folder: "{{ vsphere_folder }}"
+                hostname: "{{ vcenter_hostname }}"
+                password: "{{ vsphere_password }}"
+                name: "{{ ansible_hostname }}"
+                username: "{{ vsphere_username }}"
+              connection: local
+              register: snapshots
+
+            - name: Remove outdated snapshots
+              vmware_guest_snapshot:
+                datacenter: "{{ vsphere_datacenter }}"
+                state: absent
+                folder: "{{ vsphere_folder }}"
+                hostname: "{{ vcenter_hostname }}"
+                password: "{{ vsphere_password }}"
+                name: "{{ ansible_hostname }}"
+                snapshot_name: "{{ item.name }}"
+                username: "{{ vsphere_username }}"
+              connection: local
+              when:
+                - snapshots.guest_snapshots.snapshots is defined
+                # subtract seconds in epoch of snapshot creation from now
+                # if it is greater than X days, remove the snapshot
+                - ( (ansible_date_time.iso8601
+                     | to_datetime(date_format_ansible ))
+                  - (item.creation_time
+                      | to_datetime(date_format_snapshot))
+                  ).total_seconds()
+                  > days_to_keep_snapshots|int * 86400
+                - item.name | regex_search( "^" + snapshot_prefix )
+              loop: "{{ snapshots.guest_snapshots.snapshots }}"
+
+          # end remove snapshot block
           when:
-            - ( (ansible_date_time.iso8601 | to_datetime(date_format_ansible ))
-              - (item.creation_time        | to_datetime(date_format_snapshot))
-              ).total_seconds()
-              > days_to_keep_snapshots|int * 86400
-            - item.name | regex_search( "^" + snapshot_prefix )
             - remove_snapshot | bool
-          loop: "{{ snapshots.guest_snapshots.snapshots }}"
 
-      # end block
+      # end snapshot creation/deletion block
       when:
         - ansible_virtualization_type == "VMware"

--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -1,0 +1,36 @@
+---
+
+- name: uclalib_vmware_snapshot.yml
+  hosts: all
+  gather_facts: false
+
+  vars:
+    vcenter_hostname: vc.library.ucla.edu
+    vsphere_datacenter: "Library Information Technology"
+    vsphere_domain: "ad.library.ucla.edu"
+    vsphere_folder: "/"
+    snapshot_name: "rhel-update"
+
+  vars_prompt:
+  - name: vsphere_user
+    prompt: "(vsphere_user) vSphere User"
+    private: false
+
+  - name: vsphere_password
+    prompt: "(vsphere_password) vSphere Password"
+    private: true
+
+  tasks:
+
+  - name: Manage Snapshot
+    vmware_guest_snapshot:
+      datacenter: "{{ vsphere_datacenter }}"
+      state: "{{ (remove_snapshot | default(false)) | ternary('absent','present') }}"
+      folder: "{{ vsphere_folder }}"
+      hostname: "{{ vcenter_hostname }}"
+      password: "{{ vsphere_password }}"
+      name: "{{ inventory_hostname | regex_replace ('\\..*') }}"
+      quiesce: true
+      snapshot_name: "{{ snapshot_name }}"
+      username: "{{ vsphere_user }}@{{ vsphere_domain }}"
+    connection: local

--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -11,99 +11,104 @@
     vsphere_folder: "/"
     snapshot_prefix: "rhel-update"
     remove_snapshot: false
-    #date_format: "%Y-%m-%dT%H:%M:%S.%f%z" # for python3
-    date_format_snapshot: "%Y-%m-%dT%H:%M:%S.%f+00:00" # for python2, assuming UTC
+    # for python3
+    # date_format_snapshot: "%Y-%m-%dT%H:%M:%S.%f%z"
+    # for python2, assuming UTC
+    date_format_snapshot: "%Y-%m-%dT%H:%M:%S.%f+00:00"
     date_format_ansible: "%Y-%m-%dT%H:%M:%SZ"
     days_to_keep_snapshots: 7
     # ansible_date_time.epoch
 
 
   vars_prompt:
-  - name: vsphere_user
-    prompt: "(vsphere_user) vSphere User"
-    private: false
+    - name: vsphere_user
+      prompt: "(vsphere_user) vSphere User"
+      private: false
 
-  - name: vsphere_password
-    prompt: "(vsphere_password) vSphere Password"
-    private: true
+    - name: vsphere_password
+      prompt: "(vsphere_password) vSphere Password"
+      private: true
 
   tasks:
 
-  - name: Gathering Facts
-    setup:
-      fact_path: omit
-      gather_subset: "!all,virtual"
+    - name: Gathering Facts
+      setup:
+        fact_path: omit
+        gather_subset: "!all,virtual"
 
-  - name: Set vSphere username (implicit domain)
-    set_fact:
-      vsphere_username: "{{ vsphere_user }}{{ '@' + vsphere_domain }}"
-    when: vsphere_user is not search("@")
+    - name: Set vSphere username (implicit domain)
+      set_fact:
+        vsphere_username: "{{ vsphere_user }}{{ '@' + vsphere_domain }}"
+      when: vsphere_user is not search("@")
 
-  - name: Set vSphere username (explicit domain)
-    set_fact:
-      vsphere_username: "{{ vsphere_user }}"
-    when: vsphere_user is search("@")
+    - name: Set vSphere username (explicit domain)
+      set_fact:
+        vsphere_username: "{{ vsphere_user }}"
+      when: vsphere_user is search("@")
 
-  - debug: var=ansible_virtualization_type
-  - debug: var=ansible_hostname
-  - debug: var=vsphere_username
-  - debug: msg={{ snapshot_prefix }}-{{ ansible_date_time.date }}
+    - debug: var=ansible_virtualization_type
+    - debug: var=ansible_hostname
+    - debug: var=vsphere_username
+    - debug: msg={{ snapshot_prefix }}-{{ ansible_date_time.date }}
 
-  - block:
-      - name: Get Snapshots
-        vmware_guest_snapshot_info:
-          datacenter: "{{ vsphere_datacenter }}"
-          folder: "{{ vsphere_folder }}"
-          hostname: "{{ vcenter_hostname }}"
-          password: "{{ vsphere_password }}"
-          name: "{{ ansible_hostname }}"
-          username: "{{ vsphere_username }}"
-        connection: local
-        register: snapshots
+    - block:
+        - name: Get Snapshots
+          vmware_guest_snapshot_info:
+            datacenter: "{{ vsphere_datacenter }}"
+            folder: "{{ vsphere_folder }}"
+            hostname: "{{ vcenter_hostname }}"
+            password: "{{ vsphere_password }}"
+            name: "{{ ansible_hostname }}"
+            username: "{{ vsphere_username }}"
+          connection: local
+          register: snapshots
 
-      - debug: var=snapshots
+        - debug: var=snapshots
 
-      - name: Create Snapshots
-        vmware_guest_snapshot:
-          datacenter: "{{ vsphere_datacenter }}"
-          state: present
-          folder: "{{ vsphere_folder }}"
-          hostname: "{{ vcenter_hostname }}"
-          password: "{{ vsphere_password }}"
-          name: "{{ ansible_hostname }}"
-          quiesce: true
-          snapshot_name: "{{ snapshot_prefix }}-{{ ansible_date_time.date }}"
-          username: "{{ vsphere_username }}"
-        connection: local
-        register: out
-        when:
-          - not remove_snapshot
+        - name: Create Snapshots
+          vmware_guest_snapshot:
+            datacenter: "{{ vsphere_datacenter }}"
+            state: present
+            folder: "{{ vsphere_folder }}"
+            hostname: "{{ vcenter_hostname }}"
+            password: "{{ vsphere_password }}"
+            name: "{{ ansible_hostname }}"
+            quiesce: true
+            snapshot_name: "{{ snapshot_prefix }}-{{ ansible_date_time.date }}"
+            username: "{{ vsphere_username }}"
+          connection: local
+          register: out
+          when:
+            - not remove_snapshot
 
-      - debug: var=out
+        - debug: var=out
 
-      - debug: var=snapshots.guest_snapshots
+        - debug: var=snapshots.guest_snapshots
 
-      - name: List days of the snapshots
-        debug:
-          msg: >
-            {{
-            (
-              (ansible_date_time.iso8601 | to_datetime(date_format_ansible))
-            - (item.creation_time     | to_datetime(date_format_snapshot))
-               ).total_seconds()
-            }}
-        loop: "{{ snapshots.guest_snapshots.snapshots }}"
+        - name: List days of the snapshots
+          debug:
+            msg: >
+              {{
+              (
+                (ansible_date_time.iso8601 | to_datetime(date_format_ansible))
+              - (item.creation_time     | to_datetime(date_format_snapshot))
+                 ).total_seconds()
+              }}
+          loop: "{{ snapshots.guest_snapshots.snapshots }}"
 
 
-      - name: List the snapshot names
-        debug:
-          msg: "Snapshot: {{ item.name }} -> {{ item.creation_time | to_datetime(date_format_snapshot) }}"
-        loop: "{{ snapshots.guest_snapshots.snapshots }}"
-        when: >
-          ( (ansible_date_time.iso8601 | to_datetime(date_format_ansible))
-          - (item.creation_time     | to_datetime(date_format_snapshot)) ).total_seconds()
-          > days_to_keep_snapshots|int * 86400
+        - name: List the snapshot names
+          debug:
+            msg: >
+              Snapshot: {{ item.name }} ->
+              {{ item.creation_time | to_datetime(date_format_snapshot) }}
+          loop: "{{ snapshots.guest_snapshots.snapshots }}"
+          when: >
+            ( (ansible_date_time.iso8601 | to_datetime(date_format_ansible ))
+            - (item.creation_time        | to_datetime(date_format_snapshot))
+            ).total_seconds()
+            > days_to_keep_snapshots|int * 86400
 
-    when:
-      - ansible_virtualization_type == "VMware"
-    # end block
+      # end block
+      when:
+        - ansible_virtualization_type == "VMware"

--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -19,7 +19,6 @@
     days_to_keep_snapshots: 7
     # ansible_date_time.epoch
 
-
   vars_prompt:
     - name: vsphere_user
       prompt: "(vsphere_user) vSphere User"
@@ -30,7 +29,6 @@
       private: true
 
   tasks:
-
     - name: Gathering Facts
       setup:
         fact_path: omit
@@ -46,11 +44,6 @@
         vsphere_username: "{{ vsphere_user }}"
       when: vsphere_user is search("@")
 
-    - debug: var=ansible_virtualization_type
-    - debug: var=ansible_hostname
-    - debug: var=vsphere_username
-    - debug: msg={{ snapshot_prefix }}-{{ ansible_date_time.date }}
-
     - block:
         - name: Get Snapshots
           vmware_guest_snapshot_info:
@@ -62,8 +55,6 @@
             username: "{{ vsphere_username }}"
           connection: local
           register: snapshots
-
-        - debug: var=snapshots
 
         - name: Create Snapshots
           vmware_guest_snapshot:
@@ -77,24 +68,8 @@
             snapshot_name: "{{ snapshot_prefix }}-{{ ansible_date_time.date }}"
             username: "{{ vsphere_username }}"
           connection: local
-          register: out
           when:
             - not remove_snapshot
-
-        - debug: var=out
-
-        - debug: var=snapshots.guest_snapshots
-
-        - name: List days of the snapshots
-          debug:
-            msg: >
-              {{
-              (
-                (ansible_date_time.iso8601 | to_datetime(date_format_ansible))
-              - (item.creation_time     | to_datetime(date_format_snapshot))
-                 ).total_seconds()
-              }}
-          loop: "{{ snapshots.guest_snapshots.snapshots }}"
 
         - name: Remove outdated snapshots
           vmware_guest_snapshot:


### PR DESCRIPTION
Required:
-  `vsphere_user` (will prompt if missing)
- `vsphere_password` (will prompt if missing)

Optional:
- `remove_snapshot`  (boolean, default false, remove snapshot)
- days_to_keep_snapshots=7 (int, default 7, older snapshots should be removed)
- `snapshot_prefix` (string, default "rhel-update", only snapshots matching this prefix will be removed)

Assumes user is in the "ad.library.ucla.edu" domain.

Passes:
- [x] ansible-lint
- [x] yamllint