### PR TITLE
Change path to var_files to include encrypted and vaulted variables

### DIFF
--- a/uclalib_swarmstackdeploy.yml
+++ b/uclalib_swarmstackdeploy.yml
@@ -29,7 +29,8 @@
   become_method: sudo
   hosts: "{{ rhel_inventory_host_group }}"
   vars_files:
-    - ../group_vars/{{ rhel_inventory_host_group }}
+    - ../group_vars/{{ rhel_inventory_host_group }}/main.yml
+    - ../group_vars/{{ rhel_inventory_host_group }}/main.vault.yml
 
   roles:
     - { role: uclalib_role_swarmdeploy }


### PR DESCRIPTION
When I was separating out encrypted variables into their own vault file, I needed to change the terra groups into directories instead of the previous flat files. This broke how the deploy play referenced these files. 

To resolve this I'm explicitly stating what files need to be loaded. 