### PR TITLE
Look for prefix plus separator

### DIFF
--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -87,7 +87,7 @@
                       | to_datetime(date_format_snapshot))
                   ).total_seconds()
                   > days_to_keep_snapshots|int * 86400
-                - item.name | regex_search( "^" + snapshot_prefix )
+                - item.name | regex_search( "^" + snapshot_prefix + "-" )
               loop: "{{ snapshots.guest_snapshots.snapshots }}"
 
           # end remove snapshot block


### PR DESCRIPTION
When removing a snapshot, it looks for the prefix passed, not the prefix
passed plus a dash. so if you prefix with “pre-testing” it will create
“pre-testing-2020-02-21". If you make another one, “pre-testing-2” it
makes “pre-testing-2-2020-02-21". When you remove all the
“pre-testing-2” snapshots greater than zero days, it gets them both as
they both start with “pre-testing-2" instead of searching for
"pre-testing-2-".