### PR TITLE
[LX-824] Add task to copy UCLA VPN group vars to haproxy

### DIFF
--- a/uclalib_haproxy.yml
+++ b/uclalib_haproxy.yml
@@ -77,3 +77,11 @@
         dest: "{{ haproxy_config_dir }}/haproxy.cfg"
         validate: haproxy -c -f %s
       become: true
+
+    - name: Deploy UCLA VPN ACL source
+      copy:
+        content: "{{ ucla_vpn_networks | join('\n') }}"
+        dest: "{{ haproxy_config_dir  }}/ucla_vpn_networks"
+        owner: "root"
+        group: "root"
+        mode: 0644


### PR DESCRIPTION
The new task will read from group_vars and populate an ACL source file in `/etc/haproxy/ucla_vpn_networks`. This will allow any frontend to be able to use this ACL resource.