### PR TITLE
Insert tasks to check RHEL subscription status before yum udpate

### DIFF
--- a/uclalib_rhelupdate.yml
+++ b/uclalib_rhelupdate.yml
@@ -31,6 +31,16 @@
   any_errors_fatal: False
 
   tasks:
+    - name: Get RHEL Subscription Status
+      command: >
+        subscription-manager list --consumed --pool-only
+      register: subscription_status
+
+    - name: Fail if host not attached to RHEL Subscription
+      fail:
+        msg: "This host is not attached to a RHEL Subscription"
+      when: subscription_status.stdout | length == 0
+
     - name: Execute RHEL yum update
       yum:
         name: "*"


### PR DESCRIPTION
Output of `subscription-manager list --consumed --pool-only` is the pool ID of the entitlement. 

If the system is not attached to any entitlement, stdout will be zero length, and the play should stop before running `yum update` task. 