### PR TITLE
Bypass SSL verification

### DIFF
--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -68,6 +68,7 @@
             quiesce: true
             snapshot_name: "{{ snapshot_prefix }}-{{ ansible_date_time.date }}"
             username: "{{ vsphere_username }}"
+            validate_certs: false
           connection: local
           when:
             - not remove_snapshot|bool
@@ -82,6 +83,7 @@
                 password: "{{ vsphere_password }}"
                 name: "{{ ansible_hostname }}"
                 username: "{{ vsphere_username }}"
+                validate_certs: false
               connection: local
               register: snapshots
 
@@ -95,6 +97,7 @@
                 name: "{{ ansible_hostname }}"
                 snapshot_name: "{{ item.name }}"
                 username: "{{ vsphere_username }}"
+                validate_certs: false
               connection: local
               when:
                 - snapshots.guest_snapshots.snapshots is defined


### PR DESCRIPTION
Ansible is failing to connect to vSphere:
`fatal: [p-u-calursussolrslave01.library.ucla.edu]: FAILED! => {"changed": false, "msg": "Unable to connect to vCenter or ESXi API at vc.library.ucla.edu on TCP/443: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618)"}`

Bypass the SSL verficiation until the intermediate chain is updated.