### PR TITLE
Enable Jenkins deploy to allow stack traces

### DIFF
--- a/uclalib_ansible_capdeploy.yml
+++ b/uclalib_ansible_capdeploy.yml
@@ -82,6 +82,17 @@
           state: "link"
         when: allow_web_crawl == "no"
 
+      - name: Enable Stack Tracing
+        lineinfile:
+          path: '{{ cap_base }}/{{ project_name }}/current/config/environments/production.rb'
+          line: '\1true'
+          regexp: '(\s*config.consider_all_requests_local\s*=\s*)false'
+          backrefs: true
+          state: present
+        when:
+          - (allow_stack_trace|default('false')) | bool
+          - (stack_trace|default('false')) | bool
+
       - name: Restart Apache HTTPD to reload passenger application
         systemd:
           name: httpd


### PR DESCRIPTION
Production systems will never allow stack traces.
Stack traces are disabled by default.

`allow_stack_trace` must be explicitly set to true(yes) to allow
stack traces in browser. Explicitly set to "false" on production
systems for documentation.