### PR TITLE
Force-install bundler gem

### DIFF
--- a/uclalib_ansible_capdeploy.yml
+++ b/uclalib_ansible_capdeploy.yml
@@ -54,6 +54,7 @@
         gem:
           name: bundler
           version: '{{ bundler_version.stdout | trim }}'
+          force: true
           state: present
           user_install: false
 


### PR DESCRIPTION
Bypasses `bundler's executable "bundle" conflicts with /usr/bin/bundle`
question