### PR TITLE
Increase reboot timeout to five minutes

### DIFF
--- a/uclalib_rhelreboot.yml
+++ b/uclalib_rhelreboot.yml
@@ -51,7 +51,7 @@
 
     - name: Reboot if required
       reboot:
-        reboot_timeout: 180
+        reboot_timeout: 300
       when: >
         needs_restarting.rc == 1
         and (needs_restarting.stdout | default("")) is search ("Reboot is required")


### PR DESCRIPTION
Some systems take longer than the current three minutes.
Jenkins flags those as errors. This commit attempts to decrease the
number of false negatives.