### PR TITLE
Remove fact gathering

### DIFF
--- a/uclalib_rhelupdate.yml
+++ b/uclalib_rhelupdate.yml
@@ -24,11 +24,10 @@
 ###############################################################################
 
 - name: uclalib_rhelupdate.yml
-  become: yes
-  become_method: sudo
   hosts: "{{ rhel_inventory_host_group | default('unattended_yum_update') }}"
   serial: "{{ rhelupdate_serial | default(20) }}"
-  any_errors_fatal: False
+  any_errors_fatal: false
+  gather_facts: false
 
   tasks:
     - name: Get RHEL Subscription Status
@@ -36,6 +35,7 @@
         subscription-manager list --consumed --pool-only
       changed_when: false
       check_mode: false
+      become: true
       register: subscription_status
 
     - name: Fail if host not attached to RHEL Subscription
@@ -46,5 +46,6 @@
     - name: Execute RHEL yum update
       yum:
         name: "*"
-        state: latest
+        state: latest  # noqa: package-latest
         security: "{{ ( security_only | default (false) ) | bool }}"
+      become: true

--- a/uclalib_rhelupdatedownload.yml
+++ b/uclalib_rhelupdatedownload.yml
@@ -24,17 +24,16 @@
 ###############################################################################
 
 - name: uclalib_rhelupdatedownload.yml
-  become: yes
-  become_method: sudo
   hosts: "{{ rhel_inventory_host_group | default('unattended_yum_update') }}"
   serial: "{{ rhelupdatedownload_serial | default(15) }}"
-  any_errors_fatal: False
+  any_errors_fatal: false
+  gather_facts: false
 
   tasks:
     - name: Download RHEL Updates
       yum:
         name: "*"
-        state: latest
-        download_only: True
+        state: latest  # noqa: package-latest
+        download_only: true
         security: "{{ ( security_only | default (false) ) | bool }}"
-      register: update_status
+      become: true


### PR DESCRIPTION
- Saves up to five seconds per invocation
- Prevents hanging when GPG signing keys are updated

Other changes:

- move become to per-task
- adjust booleans to match linter expectations
- silenced linter warnings
  - we are intentional with our use of "latest"