### PR TITLE
Update YUM cache

### DIFF
--- a/uclalib_rhelupdatedownload.yml
+++ b/uclalib_rhelupdatedownload.yml
@@ -36,4 +36,5 @@
         state: latest  # noqa: package-latest
         download_only: true
         security: "{{ ( security_only | default (false) ) | bool }}"
+        update_cache: true
       become: true


### PR DESCRIPTION
Some systems were skipped for some patches. Investigation pointed to outdated yum caches being the culprit.

If this fix is insufficient, a direct call too `yum makecache` is the next step in resolving it.

JIRA: LX-1396 / Investigate why systems skipped in quarterly patching