### PR TITLE
Force type casting

### DIFF
--- a/uclalib_packer.yml
+++ b/uclalib_packer.yml
@@ -98,7 +98,7 @@
 
     - name: Set Provisioning Script
       set_fact:
-        playbook_file: '{{ convert_to_template | ternary (provisioner.template, provisioner.vm) }}'
+        playbook_file: '{{ (convert_to_template | bool) | ternary (provisioner.template, provisioner.vm) }}'
       when:
         - playbook_file is not defined
 


### PR DESCRIPTION
A defined string resolves to "true" in a boolean context, even when the value is "false"

The `bool` filter resolves the string "false" to a boolean "false"