### PR TITLE
Add linting rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,10 @@
+---
+# .ansible-lint
+# https://ansible.readthedocs.io/projects/lint/configuring/#ansible-lint-configuration
+
+profile: production
+
+skip_list:
+  - name[casing]
+  - fqcn[action]
+  - fqcn[action-core]


### PR DESCRIPTION
Skipping the nit-pickier checks
- FQCN (we are still on ansible 2.9.27)
- Task names begin with capital letter (nice, but, unnecessary)