### PR TITLE
Skip dumping tablespaces

### DIFF
--- a/californica/uclalib_californica_backup.yml
+++ b/californica/uclalib_californica_backup.yml
@@ -46,7 +46,7 @@
 
     - name: Dump Californica Rails App database
       shell: >
-        mysqldump californicadb{{ server_environ }} >
+        mysqldump --no-tablespaces californicadb{{ server_environ }} >
         /mnt/samvera_backup/californica_{{ env_date_time }}/californicadb{{ server_environ }}_{{ansible_date_time.date}}.sql
 
     - name: Copy Redis database
@@ -95,7 +95,7 @@
 
     - name: Dump fedora database
       shell: >
-        mysqldump fedora_californica_{{ server_environ }} >
+        mysqldump --no-tablespaces fedora_californica_{{ server_environ }} >
         /mnt/samvera_backup/californica_{{ env_date_time }}/fedora_californica_{{ server_environ }}_{{ansible_date_time.date}}.sql
 
     - name: Create fedora data store backup directory in backup mount


### PR DESCRIPTION
Breaking change with MySQL 5.7

Resolves
  mysqldump: Error: 'Access denied; you need (at least one of) the
  PROCESS privilege(s) for this operation' when trying to dump
  tablespaces

https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html#mysqld-5-7-31-security https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-21.html#mysqld-8-0-21-security