### PR TITLE
Use correct python interpreter

### DIFF
--- a/uclalib_vmware_snapshot.yml
+++ b/uclalib_vmware_snapshot.yml
@@ -45,6 +45,10 @@
         fact_path: omit
         gather_subset: "!all,virtual"
 
+    - name: Use standard python
+      set_fact:
+        ansible_python_interpreter: /usr/libexec/platform-python
+
     - name: Set vSphere username (implicit domain)
       set_fact:
         vsphere_username: "{{ vsphere_user + '@' + vsphere_domain }}"

--- a/uclalib_vmware_snapshot_report.yml
+++ b/uclalib_vmware_snapshot_report.yml
@@ -32,6 +32,10 @@
         fact_path: omit
         gather_subset: "!all,virtual"
 
+    - name: Use standard python
+      set_fact:
+        ansible_python_interpreter: /usr/libexec/platform-python
+
     - name: Get Snapshots
       vmware_guest_snapshot_info:
         datacenter: "{{ vsphere_datacenter }}"


### PR DESCRIPTION
Not all hosts discover the same python, causing connection: local to use the wrong (non-existant) python interpreter.