### PR TITLE
Clean up ansible output

### DIFF
--- a/uclalib_vmware_snapshot_report.yml
+++ b/uclalib_vmware_snapshot_report.yml
@@ -63,12 +63,25 @@
         create: true
         state: present
       connection: local
-      notify: Print Report
+      notify:
+        - Read Report
+        - Print Report
+        - Print Report Path
       loop: '{{ snapshots.guest_snapshots.snapshots }}'
+
+    - name: Read Report
+      slurp:
+        src: '{{ report_pathname }}'
+      register: snapshot_report
+      run_once: true
+      connection: local
 
     - name: Print Report
       debug:
-        msg: '{{ item }}'
-      with_file:
-        - '{{ report_pathname }}'
+        msg: '{{ snapshot_report.content | b64decode }}'
+      run_once: true
+
+    - name: Print Report Path
+      debug:
+        msg: 'Report saved to "{{ report_pathname }}"'
       run_once: true


### PR DESCRIPTION
- Read entire report in
- Display report, without looping
  - prevents record duplication
- Display location of report path