### PR TITLE
Add algif_aead to initcall blacklist

### DIFF
--- a/uclalib_CVE-2026-31431.yml
+++ b/uclalib_CVE-2026-31431.yml
@@ -1,0 +1,25 @@
+---
+- name: Apply CVE-2026-31431 mitigation
+  hosts: all
+  gather_facts: false
+
+  pre_tasks:
+    - name: "Gather Facts"
+      setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - "os_family"
+
+  tasks:
+    # https://access.redhat.com/solutions/7141931
+    - name: Blacklist initcall algif_aead_init
+      command:
+        argv:
+          - /usr/sbin/grubby
+          - --update-kernel=ALL
+          - --args='initcall_blacklist=algif_aead_init'
+      changed_when: true # grubby returns nothing
+      when:
+        - 'ansible_distribution == "RedHat"'
+        - 'ansible_distribution_major_version == "8"'


### PR DESCRIPTION
Mitigates CVE-2026-31431 (CopyFail) vulnerability
Effective while waiting on vendor kernel patch
- tested on a container with host applied grub update

References:
- https://access.redhat.com/security/vulnerabilities/RHSB-2026-02
- https://access.redhat.com/security/cve/cve-2026-31431
- https://access.redhat.com/solutions/7141931
- https://copy.fail/