### PR TITLE
Fix environmental variable names

### DIFF
--- a/avalon/files/compose/base.yaml
+++ b/avalon/files/compose/base.yaml
@@ -23,9 +23,9 @@ services:
       - SETTINGS__DROPBOX__PATH=/masterfiles/dropbox
       - SETTINGS__DROPBOX__UPLOAD_URI=./masterfiles/dropbox
       - SETTINGS__ENCODING__WORKING_FILE_PATH=/masterfiles
-      - SETTINGS__EMAIL__COMMENTS
-      - SETTINGS__EMAIL__NOTIFICATION
-      - SETTINGS__EMAIL__SUPPORT
+      - EMAIL__COMMENTS
+      - EMAIL__NOTIFICATION
+      - EMAIL__SUPPORT
       - ENCODE_WORK_DIR=/streamfiles
       - FEDORA_BASE_PATH
       - FEDORA_NAMESPACE=avalon


### PR DESCRIPTION
There's a discontinutiy between what the Avalon container _appears_ to expect, and what the avalon_docker is providing. Trusting the Avalon container.