### PR TITLE
Remove zabbix-release package frm server packages

### DIFF
--- a/uclalib_zabbix-update.yml
+++ b/uclalib_zabbix-update.yml
@@ -9,7 +9,6 @@
         name:
           - zabbix-apache-conf
           - zabbix-get
-          - zabbix-release
           - zabbix-selinux-policy
           - zabbix-server-pgsql
           - zabbix-sql-scripts


### PR DESCRIPTION
If we need to update the repository package, that is a bigger ordeal than simply "yum install". We'll cross that bridge when we get there.