### PR TITLE
Install rsync in the correct playbook

### DIFF
--- a/avalon/lib_avalon-conf.yaml
+++ b/avalon/lib_avalon-conf.yaml
@@ -5,6 +5,11 @@
   become: true
 
   tasks:
+    - name: Install rsync
+      packages:
+        name: rsync
+        state: present
+
     - name: Create temporary build directory
       tempfile:
         state: directory

--- a/avalon/lib_avalon8.yaml
+++ b/avalon/lib_avalon8.yaml
@@ -15,11 +15,6 @@
   become: true
 
   tasks:
-    - name: Install rsync
-      packages:
-        name: rsync
-        state: present
-
     - name: Populate volumes
       copy:
         src: volumes/{{ item }}/


### PR DESCRIPTION
Still won't solve the pre-install check
Would need to install in a more previous playbook.